### PR TITLE
zindex adjustment to work with modal forms.

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@
   overflow: hidden;
   position: fixed;
   background: rgb(0, 0, 0, 0.3);
+  z-index: 999999;
 }
 
 @keyframes open-frame {
@@ -41,7 +42,6 @@
   box-shadow: 5px 5px 10px rgb(0, 0, 0, 0.2);
   border-radius: 10px;
   animation: open-frame 0.3s linear;
-  z-index: 999999;
 }
 
 .alert-header {


### PR DESCRIPTION
This change serves to resolve the conflict between the z-index of the cute-alert modal and the modal of any other form. Analyzing the z-index attribute: 999999 it should appear in the css alert-wrapper class and not in the alert-frame.

If not applied, when using modal forms in conjunction with cute-alert, the z-index of the modal form ends up overlapping that of cute-alert.

I hope to have contributed to this project.