### PR TITLE
minimal updates for allowing multiple toasts

### DIFF
--- a/cute-alert.js
+++ b/cute-alert.js
@@ -103,15 +103,25 @@ const cuteAlert = ({
 
 const cuteToast = ({ type, message, timer = 5000 }) => {
   return new Promise((resolve) => {
-    const existingToast = document.querySelector(".toast-container");
-
-    if (existingToast) {
-      existingToast.remove();
-    }
 
     const body = document.querySelector("body");
 
+    let toastWrapper = document.querySelector(".toast-container-wrapper");
+
+    if(!toastWrapper) {
+      const template = `
+      <div class="toast-container-wrapper">
+      </div>
+      `;
+      body.insertAdjacentHTML("afterend", template);
+      toastWrapper = document.querySelector(".toast-container-wrapper");
+    }
+
+
     const scripts = document.getElementsByTagName("script");
+
+    const this_id = cuteToast.cutemaxid;
+    cuteToast.cutemaxid++;
 
     let src = "";
 
@@ -122,7 +132,7 @@ const cuteToast = ({ type, message, timer = 5000 }) => {
     }
 
     const template = `
-    <div class="toast-container ${type}-bg">
+    <div class="toast-container ${type}-bg" id="cute-${this_id}">
       <div>
         <div class="toast-frame">
           <img class="toast-img" src="${src}/img/${type}.svg" />
@@ -134,9 +144,9 @@ const cuteToast = ({ type, message, timer = 5000 }) => {
     </div>
     `;
 
-    body.insertAdjacentHTML("afterend", template);
+    toastWrapper.insertAdjacentHTML("beforeend", template);
 
-    const toastContainer = document.querySelector(".toast-container");
+    const toastContainer = document.querySelector(`.toast-container#cute-${this_id}`);
 
     setTimeout(() => {
       toastContainer.remove();
@@ -149,5 +159,9 @@ const cuteToast = ({ type, message, timer = 5000 }) => {
       toastContainer.remove();
       resolve();
     });
+
+    return this_id;
   });
 }
+
+cuteToast.cutemaxid = 0;

--- a/style.css
+++ b/style.css
@@ -234,6 +234,31 @@
   z-index: 999999;
 }
 
+.toast-container-wrapper {
+  top: 15px;
+  right: 15px;
+  position: fixed;
+  z-index: 999999;
+  display: flex;
+  flex-direction: column-reverse;
+  margin-top: -0.75em;
+  margin-bottom: -0.75em;
+}
+
+.toast-container-wrapper > * {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+
+
+.toast-container {
+  top: 0;
+  right: 0;
+  overflow: hidden;
+  position: relative;
+}
+
 .toast-frame {
   padding: 5px 15px;
   display: flex;


### PR DESCRIPTION
I like the style and that dialog and toasts in the same lib.
But single toast on the page is not the real-life case I can imagine. Multiple of events may happen on backend and each should be represented by its own toast.

This pull request contains minimal changes to code for having multiple toasts in the same style as single was.

This is enough to go for my project at the moment.
In the future is better to move to object-like style, add events-callbacks for clicking/closing and 4-8 layouts.