### PR TITLE
fix: problem not showing img in alert

### DIFF
--- a/cute-alert.js
+++ b/cute-alert.js
@@ -56,13 +56,26 @@ const cuteAlert = ({
     const template = `
     <div class="alert-wrapper">
       <div class="alert-frame">
-        ${img !== '' ? '<div class="alert-header ' + type + '-bg">' : '<div>'}
+        ${
+          img === undefined
+            ? '<div class="alert-header ' + type + '-bg">'
+            : '<div class="alert-header-base">'
+        }
           <span class="alert-close ${
             closeStyle === 'circle'
               ? 'alert-close-circle'
               : 'alert-close-default'
           }">X</span>
-          ${img !== '' ? '<img class="alert-img" src="' + src + '/' + img + '" />' : ''}
+          ${
+            img === undefined
+              ? '<img class="alert-img" src="' +
+                src +
+                "/img/" +
+                type +
+                ".svg" +
+                '" />'
+              : '<div class="custom-img-wrapper">' + img + "</div>"
+          }
         </div>
         <div class="alert-body">
           <span class="alert-title">${title}</span>

--- a/style.css
+++ b/style.css
@@ -52,6 +52,20 @@
   border-top-right-radius: 5px;
 }
 
+.alert-header-base {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+
+.custom-img-wrapper {
+  min-height: 145px;
+  max-height: 20rem;
+  overflow: scroll;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .alert-img {
   height: 80px;
   position: absolute;


### PR DESCRIPTION
I had a problem showing image whether I pass `img` key or not. 
So, I want you to fix this problem. I want me to help you to do that.

In the previous code, whether I pass `img` key or not, `img !== '' ` was **`true`**.
I changed from `img !== '' `  to `img === undefined`. It works well now.

The image in **img** folder was not visible. Images are in **img** folder, and the extension of them are **svg**.
Right. This was already discussed in issue. I also fixed it. 


And, I wanted img to be shown like `display: block;`. So, I added `.alert-header-base` and `.alert-img` in css file.
The name of key is img. But, I can add any html element. 
This is when I added a table tag as a value of img key.
```
cuteAlert({
    type: "success",
    title: "GAME END",
    message: `당신은 ${
      scoreData.map((arr) => arr[0]).indexOf(player_name) + 1
    }등을 하셨습니다`,
    img: `<table class='table'>
            <thead class='table-dark'>
              <tr>
                <th>player</th>
                <th>score</th>
              </tr>
            </thead>
            <tbody>
              ${tableElement}
            </tbody>
          </table>`,
    buttonText: "NEXT",
  })
```
![image](https://user-images.githubusercontent.com/86035717/210071695-870b12bf-df51-42b1-b0ec-116e5f43335b.png)

